### PR TITLE
Fix batch loader dependency

### DIFF
--- a/lib/ams_lazy_relationships.rb
+++ b/lib/ams_lazy_relationships.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "batch-loader"
+
 require "ams_lazy_relationships/version"
 require "ams_lazy_relationships/loaders"
 require "ams_lazy_relationships/core"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,7 +12,6 @@ require "ams_lazy_relationships"
 
 require "undercover"
 require "with_model"
-require "batch-loader"
 require "pry"
 require "db-query-matchers"
 


### PR DESCRIPTION
It fixes the exceptions like `NameError: uninitialized constant AmsLazyRelationships::Loaders::SimpleHasMany::BatchLoader` when `ams_lazy_relationships` gem is bundled to the application without explicit `batch-loader` dependency.

That is good approach for the gem to `require` the dependencies within its root `lib` file, like [devise do](https://github.com/plataformatec/devise/blob/master/lib/devise.rb).