### PR TITLE
Fix nested serializer lookup

### DIFF
--- a/lib/ams_lazy_relationships/core/evaluation.rb
+++ b/lib/ams_lazy_relationships/core/evaluation.rb
@@ -49,8 +49,15 @@ module AmsLazyRelationships::Core
       return unless lrm.reflection
 
       Array.wrap(batch_records).each do |r|
-        lrm.serializer_class.send(:load_all_lazy_relationships, r, level + 1)
+        deep_load_for_yielded_record(r, lrm, level)
       end
+    end
+
+    def deep_load_for_yielded_record(batch_record, lrm, level)
+      serializer = serializer_for(batch_record, lrm.reflection.options)
+      return unless serializer
+
+      serializer.send(:load_all_lazy_relationships, batch_record, level + 1)
     end
   end
 end

--- a/lib/ams_lazy_relationships/core/lazy_relationship_meta.rb
+++ b/lib/ams_lazy_relationships/core/lazy_relationship_meta.rb
@@ -19,17 +19,5 @@ module AmsLazyRelationships::Core
     end
 
     attr_reader :name, :loader, :reflection, :load_for
-
-    # @return [ActiveModel::Serializer] AMS Serializer class for the relationship
-    def serializer_class
-      return @serializer_class if defined?(@serializer_class)
-
-      @serializer_class =
-        if AmsLazyRelationships::Core.ams_version <= Gem::Version.new("0.10.0.rc2")
-          reflection[:association_options][:serializer]
-        else
-          reflection.options[:serializer]
-        end
-    end
   end
 end


### PR DESCRIPTION
It fixes #30 

`undefined method 'load_all_lazy_relationships' for nil:NilClass` exception is raising in specific env.

Lets fix two yet different causes of this:
1) host application uses customized serializers lookup (`ActiveModelSerializers.config.serializer_lookup_chain`), so `ams_lazy_relationships` should use the same lookup in order to get the same result;
2) in case of missed serializer, `ActiveModelSerializers` will inline nested object right into `relationships` as it is, so `ams_lazy_relationships` should keep rolling as well.