### PR TITLE
Synchronize lazy relationships

### DIFF
--- a/lib/ams_lazy_relationships/core/lazy_relationship_method.rb
+++ b/lib/ams_lazy_relationships/core/lazy_relationship_method.rb
@@ -39,7 +39,15 @@ module AmsLazyRelationships::Core
       @lazy_relationships[name] = lrm
 
       define_method :"lazy_#{name}" do
-        self.class.send(:load_lazy_relationship, lrm, object)
+        # We need to evaluate the promise right before serializer tries
+        # to touch it. Otherwise the various side effects can happen:
+        # 1. AMS will attempt to serialize nil values with a specific V1 serializer
+        # 2. `lazy_association ? 'exists' : 'missing'` expression will always
+        #     equal to 'exists'
+        # 3. `lazy_association&.id` expression can raise NullPointer exception
+        #
+        # Calling `__sync` will evaluate the promise.
+        self.class.send(:load_lazy_relationship, lrm, object).__sync
       end
     end
 

--- a/lib/ams_lazy_relationships/core/relationship_wrapper_methods.rb
+++ b/lib/ams_lazy_relationships/core/relationship_wrapper_methods.rb
@@ -30,11 +30,7 @@ module AmsLazyRelationships::Core
       real_relationship_options = options.except(*lazy_relationship_option_keys)
 
       block ||= lambda do |serializer|
-        # We need to evaluate the promise right before AMS tries
-        # to serialize it. Otherwise AMS will attempt to serialize nil values
-        # with a specific V1 serializer.
-        # Calling `itself` will evaluate the promise.
-        serializer.public_send("lazy_#{name}").tap(&:itself)
+        serializer.public_send("lazy_#{name}")
       end
 
       public_send(type, name.to_sym, real_relationship_options, &block)

--- a/spec/core_spec.rb
+++ b/spec/core_spec.rb
@@ -339,6 +339,14 @@ RSpec.describe AmsLazyRelationships::Core do
                      loader: AmsLazyRelationships::Loaders::Association.new(
                        "Comment", :user
                      )
+
+        attribute :conditional_level1 do
+          lazy_level1 ? 'exists' : 'missing'
+        end
+
+        attribute :safe_navigated_level1 do
+          lazy_level1&.id
+        end
       end
 
       Level0Serializer4
@@ -347,6 +355,30 @@ RSpec.describe AmsLazyRelationships::Core do
     it "provides a convenience method for lazy relationships" do
       id = json.dig(:comment, :level1, :id).to_i
       expect(id).to eq(comment.user_id)
+    end
+
+    it "realizes the presence of relationship object through trivial condition" do
+      conditional_level1 = json.dig(:comment, :conditional_level1)
+      expect(conditional_level1).to eq('exists')
+    end
+
+    it "realizes the presence of relationship object through safe navigation" do
+      conditional_level1 = json.dig(:comment, :safe_navigated_level1)
+      expect(conditional_level1).to eq(user.id)
+    end
+
+    context 'missing level1' do
+      let(:comment) { Comment.create!(user_id: nil) }
+
+      it "realizes the absence of relationship object through trivial condition" do
+        conditional_level1 = json.dig(:comment, :conditional_level1)
+        expect(conditional_level1).to eq('missing')
+      end
+
+      it "realizes the absence of relationship object through safe navigation" do
+        conditional_level1 = json.dig(:comment, :safe_navigated_level1)
+        expect(conditional_level1).to be_nil
+      end
     end
   end
 
@@ -366,6 +398,14 @@ RSpec.describe AmsLazyRelationships::Core do
                      loader: AmsLazyRelationships::Loaders::Association.new(
                        "Comment", :user
                      )
+
+        attribute :conditional_level1 do
+          lazy_level1 ? 'exists' : 'missing'
+        end
+
+        attribute :safe_navigated_level1 do
+          lazy_level1&.id
+        end
       end
 
       Level0Serializer5
@@ -374,6 +414,30 @@ RSpec.describe AmsLazyRelationships::Core do
     it "provides a convenience method for lazy relationships" do
       id = json.dig(:comment, :level1, :id).to_i
       expect(id).to eq(comment.user_id)
+    end
+
+    it "realizes the presence of relationship object through trivial condition" do
+      conditional_level1 = json.dig(:comment, :conditional_level1)
+      expect(conditional_level1).to eq('exists')
+    end
+
+    it "realizes the presence of relationship object through safe navigation" do
+      conditional_level1 = json.dig(:comment, :safe_navigated_level1)
+      expect(conditional_level1).to eq(user.id)
+    end
+
+    context 'missing level1' do
+      let(:comment) { Comment.create!(user_id: nil) }
+
+      it "realizes the absence of relationship object through trivial condition" do
+        conditional_level1 = json.dig(:comment, :conditional_level1)
+        expect(conditional_level1).to eq('missing')
+      end
+
+      it "realizes the absence of relationship object through safe navigation" do
+        conditional_level1 = json.dig(:comment, :safe_navigated_level1)
+        expect(conditional_level1).to be_nil
+      end
     end
 
     describe "passing block to lazy_belongs_to" do


### PR DESCRIPTION
`BatchLoader` behaves like a methods delegator but still can't delegate pure ruby operators:

```ruby
class Level0Serializer4 < BaseTestSerializer
  lazy_has_one :level1

  attribute :conditional_level1 do
    # lazy_level1 is the instance of `BatchLoader` so the result will be always `exists`
    lazy_level1 ? 'exists' : 'missing'
  end

  attribute :safe_navigated_level1 do
    # lazy_level1 is the instance of `BatchLoader` so it will be always considered as
    # `not nil` by safe navigation operator. Then `id` method will be sent and
    # this time it will land to delegation object with a chance to raise
    # `NoMethodError: undefined method `id' for nil:NilClass`
    lazy_level1&.id
  end
end
```

Fortunately `BatchLoader` class provides public `__sync` method which instantly lands to delegation object keeping alive the laziness evaluation. This method is used by `batch-loader` gem itself for [`graphql` integration](https://github.com/exAspArk/batch-loader/blob/v1.4.1/lib/batch_loader/graphql.rb#L43). Lets do the same within our `lazy_<relationship>` instance methods.