### PR TITLE
Filter out preloaded records in `Association` preloader

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ gemfile:
   - gemfiles/ams_0.10.8.gemfile
 cache: bundler
 rvm:
-  - 2.3.4
+  - 2.5.3
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ cache: bundler
 rvm:
   - 2.3.4
 before_install:
-  - gem install -v 1.17.2 bundler --no-rdoc --no-ri
+  - gem install -v 1.17.2 bundler --no-ri
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ cache: bundler
 rvm:
   - 2.3.4
 before_install:
-  - gem install -v 1.17.2 bundler --no-ri
+  - gem install -v 1.17.2 bundler
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ gemfile:
 cache: bundler
 rvm:
   - 2.3.4
-before_install:
-  - gem install -v 1.17.2 bundler
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ cache: bundler
 rvm:
   - 2.3.4
 before_script:
+  - gem install -v 1.17.2 bundler --no-rdoc --no-ri
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter
   - ./cc-test-reporter before-build

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,9 @@ gemfile:
 cache: bundler
 rvm:
   - 2.3.4
-before_script:
+before_install:
   - gem install -v 1.17.2 bundler --no-rdoc --no-ri
+before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter
   - ./cc-test-reporter before-build

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -185,7 +185,6 @@ DEPENDENCIES
   ams_lazy_relationships!
   appraisal
   benchmark-memory (~> 0.1)
-  bundler (~> 1.17)
   db-query-matchers
   github_changelog_generator
   pry
@@ -202,4 +201,4 @@ DEPENDENCIES
   with_model (~> 2.0)
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -164,7 +164,7 @@ GEM
     simplecov-html (0.10.2)
     simplecov-lcov (0.7.0)
     slop (3.6.0)
-    sqlite3 (1.4.2)
+    sqlite3 (1.3.13)
     thor (0.20.3)
     thread_safe (0.3.6)
     tzinfo (1.2.5)
@@ -196,7 +196,7 @@ DEPENDENCIES
   rubocop-rspec (= 1.20.1)
   simplecov
   simplecov-lcov
-  sqlite3 (~> 1.4.0)
+  sqlite3
   undercover
   with_model (~> 2.0)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -164,7 +164,7 @@ GEM
     simplecov-html (0.10.2)
     simplecov-lcov (0.7.0)
     slop (3.6.0)
-    sqlite3 (1.3.13)
+    sqlite3 (1.4.2)
     thor (0.20.3)
     thread_safe (0.3.6)
     tzinfo (1.2.5)
@@ -196,7 +196,7 @@ DEPENDENCIES
   rubocop-rspec (= 1.20.1)
   simplecov
   simplecov-lcov
-  sqlite3 (~> 1.3.6)
+  sqlite3 (~> 1.4.0)
   undercover
   with_model (~> 2.0)
 

--- a/ams_lazy_relationships.gemspec
+++ b/ams_lazy_relationships.gemspec
@@ -51,7 +51,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop-rspec", "= 1.20.1"
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "simplecov-lcov"
-  spec.add_development_dependency "sqlite3", "~> 1.4.0"
+  spec.add_development_dependency "sqlite3"
   # Detect untested code blocks in recent changes
   spec.add_development_dependency "undercover"
   # Dynamically build an Active Record model (with table) within a test context

--- a/ams_lazy_relationships.gemspec
+++ b/ams_lazy_relationships.gemspec
@@ -39,7 +39,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "activerecord"
   # A Ruby library for testing against different versions of dependencies
   spec.add_development_dependency "appraisal"
-  spec.add_development_dependency "bundler", "~> 1.17"
   # Rspec matchers for SQL query counts
   spec.add_development_dependency "db-query-matchers"
   spec.add_development_dependency "github_changelog_generator"

--- a/ams_lazy_relationships.gemspec
+++ b/ams_lazy_relationships.gemspec
@@ -51,7 +51,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop-rspec", "= 1.20.1"
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "simplecov-lcov"
-  spec.add_development_dependency "sqlite3", "~> 1.3.6"
+  spec.add_development_dependency "sqlite3", "~> 1.4.0"
   # Detect untested code blocks in recent changes
   spec.add_development_dependency "undercover"
   # Dynamically build an Active Record model (with table) within a test context

--- a/lib/ams_lazy_relationships/loaders/association.rb
+++ b/lib/ams_lazy_relationships/loaders/association.rb
@@ -36,7 +36,9 @@ module AmsLazyRelationships
         # in a decorator and non-wrapped). In this case Associations::Preloader
         # stores duplicated records in has_many relationships for some reason.
         # Calling uniq(&:id) solves the problem.
-        records_to_preload = records.uniq(&:id)
+        records_to_preload = records.uniq(&:id).reject do |r|
+          r.association(association_name).loaded?
+        end
 
         ::ActiveRecord::Associations::Preloader.new.preload(
           records_to_preload, association_name

--- a/lib/ams_lazy_relationships/loaders/association.rb
+++ b/lib/ams_lazy_relationships/loaders/association.rb
@@ -32,16 +32,8 @@ module AmsLazyRelationships
       attr_reader :model_class_name, :association_name
 
       def load_data(records, loader)
-        # It may happen that same record comes here twice (e.g. wrapped
-        # in a decorator and non-wrapped). In this case Associations::Preloader
-        # stores duplicated records in has_many relationships for some reason.
-        # Calling uniq(&:id) solves the problem.
-        records_to_preload = records.uniq(&:id).reject do |r|
-          r.association(association_name).loaded?
-        end
-
         ::ActiveRecord::Associations::Preloader.new.preload(
-          records_to_preload, association_name
+          records_to_preload(records), association_name
         )
 
         data = []
@@ -56,6 +48,16 @@ module AmsLazyRelationships
 
       def batch_key
         "#{model_class_name}/#{association_name}"
+      end
+
+      def records_to_preload(records)
+        # It may happen that same record comes here twice (e.g. wrapped
+        # in a decorator and non-wrapped). In this case Associations::Preloader
+        # stores duplicated records in has_many relationships for some reason.
+        # Calling uniq(&:id) solves the problem.
+        records.uniq(&:id).reject do |r|
+          r.association(association_name).loaded?
+        end
       end
     end
   end

--- a/spec/loaders/association_spec.rb
+++ b/spec/loaders/association_spec.rb
@@ -58,11 +58,7 @@ RSpec.describe AmsLazyRelationships::Loaders::Association do
 
             expect(c1).to eq(blog_post)
             expect(c2).to eq(blog_post2)
-          end.to make_database_queries(
-            count: 1,
-            # If blog_post wasn't cached then a query with "id" IN() would be called
-            matching: /SELECT.*FROM.*blog_posts.*WHERE.*blog_posts.*\"id\" = /
-          )
+          end.not_to make_database_queries
         end
       end
     end

--- a/spec/loaders/association_spec.rb
+++ b/spec/loaders/association_spec.rb
@@ -58,7 +58,11 @@ RSpec.describe AmsLazyRelationships::Loaders::Association do
 
             expect(c1).to eq(blog_post)
             expect(c2).to eq(blog_post2)
-          end.not_to make_database_queries
+          end.to make_database_queries(
+            count: 1,
+            # If blog_post wasn't cached then a query with "id" IN() would be called
+            matching: /SELECT.*FROM.*blog_posts.*WHERE.*blog_posts.*\"id\" = /
+          )
         end
       end
     end


### PR DESCRIPTION
Also fixes some problems with travis builds:
- Upgrades ruby version from 2.3 -> 2.5 
- Removes `bundler` dependency
- Makes `sqlite3` dependency less strict

closes https://github.com/Bajena/ams_lazy_relationships/issues/37