### PR TITLE
Pass serialization scope to lazy loaders

### DIFF
--- a/lib/ams_lazy_relationships/core.rb
+++ b/lib/ams_lazy_relationships/core.rb
@@ -50,7 +50,7 @@ module AmsLazyRelationships::Core
     def initialize(*)
       super
 
-      self.class.send(:init_all_lazy_relationships, object)
+      self.class.send(:init_all_lazy_relationships, object, scope)
     end
   end
 end

--- a/lib/ams_lazy_relationships/core/evaluation.rb
+++ b/lib/ams_lazy_relationships/core/evaluation.rb
@@ -81,7 +81,7 @@ module AmsLazyRelationships::Core
       end
     end
 
-    def deep_init_for_yielded_record(batch_record, lrm, level)
+    def deep_init_for_yielded_record(batch_record, scope, lrm, level)
       serializer = lazy_serializer_for(batch_record, lrm: lrm)
       return unless serializer
 

--- a/lib/ams_lazy_relationships/core/lazy_dig_method.rb
+++ b/lib/ams_lazy_relationships/core/lazy_dig_method.rb
@@ -69,7 +69,8 @@ module AmsLazyRelationships::Core
       serializer&.send(
         :load_lazy_relationship,
         relation_name,
-        object
+        object,
+        scope
       )
     end
 

--- a/lib/ams_lazy_relationships/core/lazy_relationship_method.rb
+++ b/lib/ams_lazy_relationships/core/lazy_relationship_method.rb
@@ -39,7 +39,7 @@ module AmsLazyRelationships::Core
       @lazy_relationships[name] = lrm
 
       define_method :"lazy_#{name}" do
-        self.class.send(:load_lazy_relationship, name, object)
+        self.class.send(:load_lazy_relationship, name, object, scope)
       end
     end
 

--- a/lib/ams_lazy_relationships/loaders/association.rb
+++ b/lib/ams_lazy_relationships/loaders/association.rb
@@ -21,7 +21,7 @@ module AmsLazyRelationships
 
       attr_reader :model_class_name, :association_name
 
-      def load_data(records, loader, scope)
+      def load_data(records, loader, _scope)
         ::ActiveRecord::Associations::Preloader.new.preload(
           records_to_preload(records), association_name
         )

--- a/lib/ams_lazy_relationships/loaders/association.rb
+++ b/lib/ams_lazy_relationships/loaders/association.rb
@@ -21,7 +21,7 @@ module AmsLazyRelationships
 
       attr_reader :model_class_name, :association_name
 
-      def load_data(records, loader)
+      def load_data(records, loader, scope)
         ::ActiveRecord::Associations::Preloader.new.preload(
           records_to_preload(records), association_name
         )

--- a/lib/ams_lazy_relationships/loaders/base.rb
+++ b/lib/ams_lazy_relationships/loaders/base.rb
@@ -7,9 +7,10 @@ module AmsLazyRelationships
     class Base
       # Lazy loads and yields the data when evaluating
       # @param record [Object] an object for which we're loading the data
+      # @param scope [Object] serialization scope object.
       # @param block [Proc] a block to execute when data is evaluated.
       #  Loaded data is yielded as a block argument.
-      def load(record, &block)
+      def load(record, scope = nil, &block)
         BatchLoader.for(record).batch(
           key: batch_key(record),
           # Replacing methods can be costly, especially on objects with lots
@@ -18,7 +19,7 @@ module AmsLazyRelationships
           # https://github.com/exAspArk/batch-loader/tree/v1.4.1#replacing-methods
           replace_methods: false
         ) do |records, loader|
-          data = load_data(records, loader)
+          data = load_data(records, loader, scope)
 
           block&.call(data)
         end

--- a/lib/ams_lazy_relationships/loaders/base.rb
+++ b/lib/ams_lazy_relationships/loaders/base.rb
@@ -33,8 +33,9 @@ module AmsLazyRelationships
       # @param loader [Proc] Proc used for assigning the batch loaded data to
       #   records. First argument is the record and the second is the data
       #   loaded for it.
+      # @param scope [Object] Serialization scope object.
       # @returns [Array<Object>] Array of loaded objects
-      def load_data(_records, _loader)
+      def load_data(_records, _loader, _scope)
         raise "Implement in child"
       end
 

--- a/lib/ams_lazy_relationships/loaders/direct.rb
+++ b/lib/ams_lazy_relationships/loaders/direct.rb
@@ -20,7 +20,7 @@ module AmsLazyRelationships
 
       attr_reader :relationship_name, :load_block
 
-      def load_data(records, loader)
+      def load_data(records, loader, scope)
         data = []
         records.each do |r|
           value = calculate_value(r)

--- a/lib/ams_lazy_relationships/loaders/direct.rb
+++ b/lib/ams_lazy_relationships/loaders/direct.rb
@@ -20,7 +20,7 @@ module AmsLazyRelationships
 
       attr_reader :relationship_name, :load_block
 
-      def load_data(records, loader, scope)
+      def load_data(records, loader, _scope)
         data = []
         records.each do |r|
           value = calculate_value(r)

--- a/lib/ams_lazy_relationships/loaders/simple_belongs_to.rb
+++ b/lib/ams_lazy_relationships/loaders/simple_belongs_to.rb
@@ -24,7 +24,7 @@ module AmsLazyRelationships
 
       attr_reader :association_class_name, :foreign_key
 
-      def load_data(records, loader)
+      def load_data(records, loader, scope)
         data_ids = records.map(&foreign_key).compact.uniq
         data = if data_ids.present?
                  association_class_name.constantize.where(id: data_ids)

--- a/lib/ams_lazy_relationships/loaders/simple_belongs_to.rb
+++ b/lib/ams_lazy_relationships/loaders/simple_belongs_to.rb
@@ -24,7 +24,7 @@ module AmsLazyRelationships
 
       attr_reader :association_class_name, :foreign_key
 
-      def load_data(records, loader, scope)
+      def load_data(records, loader, _scope)
         data_ids = records.map(&foreign_key).compact.uniq
         data = if data_ids.present?
                  association_class_name.constantize.where(id: data_ids)

--- a/lib/ams_lazy_relationships/loaders/simple_has_many.rb
+++ b/lib/ams_lazy_relationships/loaders/simple_has_many.rb
@@ -20,7 +20,7 @@ module AmsLazyRelationships
 
       attr_reader :association_class_name, :foreign_key
 
-      def load_data(records, loader)
+      def load_data(records, loader, scope)
         # Some records use UUID class as id - it's safer to cast them to strings
         record_ids = records.map { |r| r.id.to_s }
         association_class_name.constantize.where(

--- a/lib/ams_lazy_relationships/loaders/simple_has_many.rb
+++ b/lib/ams_lazy_relationships/loaders/simple_has_many.rb
@@ -20,7 +20,7 @@ module AmsLazyRelationships
 
       attr_reader :association_class_name, :foreign_key
 
-      def load_data(records, loader, scope)
+      def load_data(records, loader, _scope)
         # Some records use UUID class as id - it's safer to cast them to strings
         record_ids = records.map { |r| r.id.to_s }
         association_class_name.constantize.where(


### PR DESCRIPTION
It doesn't necessarily have to get to master, but I've heard some voices that it might be useful to have access to the serialization scope.

closes https://github.com/Bajena/ams_lazy_relationships/issues/41