### PR TITLE
Improve tests for nested serializer lookup

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,6 +33,8 @@ RSpec.configure do |config|
   config.extend WithModel
 
   config.before(:all) do
+    ActiveModelSerializers.config.key_transform = :unaltered
+
     ActiveRecord::Base.establish_connection(
       "adapter"  => "sqlite3",
       "database" => ":memory:"

--- a/spec/support/with_ar_models.rb
+++ b/spec/support/with_ar_models.rb
@@ -16,6 +16,10 @@ module WithArModels
       table do |t|
         t.timestamps null: false
       end
+
+      model do
+        has_many :category_followers
+      end
     end
 
     with_model :CategoryFollower do


### PR DESCRIPTION
It adds the tests for straightforward lookup for nested serializers which used by AMS right from the box. This way the nested serializer should be defined as nested class like

```
  class UserSerializer < BaseTestSerializer
    lazy_has_many :blog_posts
  end

  class UserSerializer::BlogPostSerializer < BaseTestSerializer
    lazy_belongs_to :category

    attributes :title
  end

  class UserSerializer::BlogPostSerializer::CategorySerializer < BaseTestSerializer
    attributes :created_at

    lazy_has_many :category_followers
  end
```

Also it adds the tests for customized serializer lookup starting from AMS `v0.10.3` which introduced `ActiveModelSerializers.config.serializer_lookup_chain` first time.

See also: https://github.com/Bajena/ams_lazy_relationships/pull/34