### PR TITLE
Lazy dig

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,24 @@ class BlogPostSerializer < BaseSerializer
 end
 ```
 
+#### Example 6: Lazy dig through relationships
+In additional to previous example you may want to make use of nested lazy relationship without rendering of any nested record.
+There is an `lazy_dig` method to be used for that:
+
+```ruby
+class AuthorSerializer < BaseSerializer
+  lazy_relationship :address
+end
+
+class BlogPostSerializer < BaseSerializer
+  lazy_relationship :author
+
+  attribute :author_address do
+    lazy_dig(:author, :address)&.full_address
+  end
+end
+```
+
 ## Performance comparison with vanilla AMS
 
 In general the bigger and more complex your serialized records hierarchy is and the more latency you have in your DB the more you'll benefit from using this gem. 

--- a/lib/ams_lazy_relationships/core.rb
+++ b/lib/ams_lazy_relationships/core.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "ams_lazy_relationships/core/lazy_relationship_method"
+require "ams_lazy_relationships/core/lazy_dig_method"
 require "ams_lazy_relationships/core/relationship_wrapper_methods"
 require "ams_lazy_relationships/core/evaluation"
 
@@ -18,6 +19,7 @@ module AmsLazyRelationships::Core
 
   def self.included(klass)
     klass.send :extend, ClassMethods
+    klass.send :include, LazyDigMethod
     klass.send :prepend, Initializer
 
     klass.send(:define_relationship_wrapper_methods)
@@ -48,7 +50,7 @@ module AmsLazyRelationships::Core
     def initialize(*)
       super
 
-      self.class.send(:load_all_lazy_relationships, object)
+      self.class.send(:init_all_lazy_relationships, object)
     end
   end
 end

--- a/lib/ams_lazy_relationships/core/evaluation.rb
+++ b/lib/ams_lazy_relationships/core/evaluation.rb
@@ -8,26 +8,47 @@ module AmsLazyRelationships::Core
     LAZY_NESTING_LEVELS = 3
     NESTING_START_LEVEL = 1
 
+    # Loads the lazy relationship
+    #
+    # @param relation_name [Symbol] relation name to be loaded
+    # @param object [Object] Lazy relationships will be loaded for this record.
+    def load_lazy_relationship(relation_name, object)
+      lrm = lazy_relationships[relation_name]
+      unless lrm
+        raise ArgumentError, "Undefined lazy '#{relation_name}' relationship for '#{name}' serializer"
+      end
+
+      # We need to evaluate the promise right before serializer tries
+      # to touch it. Otherwise the various side effects can happen:
+      # 1. AMS will attempt to serialize nil values with a specific V1 serializer
+      # 2. `lazy_association ? 'exists' : 'missing'` expression will always
+      #     equal to 'exists'
+      # 3. `lazy_association&.id` expression can raise NullPointer exception
+      #
+      # Calling `__sync` will evaluate the promise.
+      init_lazy_relationship(lrm, object).__sync
+    end
+
     # Recursively loads the tree of lazy relationships
     # The nesting is limited to 3 levels.
     #
     # @param object [Object] Lazy relationships will be loaded for this record.
     # @param level [Integer] Current nesting level
-    def load_all_lazy_relationships(object, level = NESTING_START_LEVEL)
+    def init_all_lazy_relationships(object, level = NESTING_START_LEVEL)
       return if level >= LAZY_NESTING_LEVELS
       return unless object
 
       return unless lazy_relationships
 
       lazy_relationships.each_value do |lrm|
-        load_lazy_relationship(lrm, object, level)
+        init_lazy_relationship(lrm, object, level)
       end
     end
 
     # @param lrm [LazyRelationshipMeta] relationship data
     # @param object [Object] Object to load the relationship for
     # @param level [Integer] Current nesting level
-    def load_lazy_relationship(lrm, object, level = NESTING_START_LEVEL)
+    def init_lazy_relationship(lrm, object, level = NESTING_START_LEVEL)
       load_for_object = if lrm.load_for.present?
                           object.public_send(lrm.load_for)
                         else
@@ -35,7 +56,7 @@ module AmsLazyRelationships::Core
                         end
 
       lrm.loader.load(load_for_object) do |batch_records|
-        deep_load_for_yielded_records(
+        deep_init_for_yielded_records(
           batch_records,
           lrm,
           level
@@ -43,21 +64,28 @@ module AmsLazyRelationships::Core
       end
     end
 
-    def deep_load_for_yielded_records(batch_records, lrm, level)
+    def deep_init_for_yielded_records(batch_records, lrm, level)
       # There'll be no more nesting if there's no
       # reflection for this relationship. We can skip deeper lazy loading.
       return unless lrm.reflection
 
       Array.wrap(batch_records).each do |r|
-        deep_load_for_yielded_record(r, lrm, level)
+        deep_init_for_yielded_record(r, lrm, level)
       end
     end
 
-    def deep_load_for_yielded_record(batch_record, lrm, level)
-      serializer = serializer_for(batch_record, lrm.reflection.options)
+    def deep_init_for_yielded_record(batch_record, lrm, level)
+      serializer = lazy_serializer_for(batch_record, lrm: lrm)
       return unless serializer
 
-      serializer.send(:load_all_lazy_relationships, batch_record, level + 1)
+      serializer.send(:init_all_lazy_relationships, batch_record, level + 1)
+    end
+
+    def lazy_serializer_for(object, lrm: nil, relation_name: nil)
+      lrm ||= lazy_relationships[relation_name]
+      return unless lrm&.reflection
+
+      serializer_for(object, lrm.reflection.options)
     end
   end
 end

--- a/lib/ams_lazy_relationships/core/lazy_dig_method.rb
+++ b/lib/ams_lazy_relationships/core/lazy_dig_method.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+module AmsLazyRelationships::Core
+  # Provides `lazy_dig` as an instance method for serializers, in order to make
+  # possible to dig relationships in depth just like `Hash#dig` do, keeping the
+  # laziness and N+1-free evaluation.
+  module LazyDigMethod
+    # @param relation_names [Array<Symbol>] the sequence of relation names
+    #   to dig through.
+    # @return [ActiveRecord::Base, Array<ActiveRecord::Base>, nil] ActiveRecord
+    #   objects found by digging through the sequence of nested relationships.
+    #   Singular or plural nature of returned value depends from the
+    #   singular/plural nature of the chain of relation_names.
+    #
+    # @example
+    #   class AuthorSerializer < BaseSerializer
+    #     lazy_belongs_to :address
+    #     lazy_has_many :rewards
+    #   end
+    #
+    #   class BlogPostSerializer < BaseSerializer
+    #     lazy_belongs_to :author
+    #
+    #     attribute :author_address do
+    #       # returns single AR object or nil
+    #       lazy_dig(:author, :address)&.full_address
+    #     end
+    #
+    #     attribute :author_rewards do
+    #       # returns an array of AR objects
+    #       lazy_dig(:author, :rewards).map(&:description)
+    #     end
+    #   end
+    def lazy_dig(*relation_names)
+      relationships = {
+        multiple: false,
+        data: [{
+          serializer: self.class,
+          object: object
+        }]
+      }
+
+      relation_names.each do |relation_name|
+        lazy_dig_relationship!(relation_name, relationships)
+      end
+
+      objects = relationships[:data].map { |r| r[:object] }
+
+      relationships[:multiple] ? objects : objects.first
+    end
+
+    private
+
+    def lazy_dig_relationship!(relation_name, relationships)
+      relationships[:data].map! do |serializer:, object:|
+        next_objects = lazy_dig_next_objects!(relation_name, serializer, object)
+        next unless next_objects
+
+        relationships[:multiple] ||= next_objects.respond_to?(:to_ary)
+
+        lazy_dig_next_relationships!(relation_name, serializer, next_objects)
+      end
+
+      relationships[:data].flatten!
+      relationships[:data].compact!
+    end
+
+    def lazy_dig_next_objects!(relation_name, serializer, object)
+      serializer&.send(
+        :load_lazy_relationship,
+        relation_name,
+        object
+      )
+    end
+
+    def lazy_dig_next_relationships!(relation_name, serializer, next_objects)
+      Array.wrap(next_objects).map do |next_object|
+        next_serializer = serializer.send(
+          :lazy_serializer_for,
+          next_object,
+          relation_name: relation_name
+        )
+
+        {
+          serializer: next_serializer,
+          object: next_object
+        }
+      end
+    end
+  end
+end

--- a/lib/ams_lazy_relationships/core/lazy_relationship_method.rb
+++ b/lib/ams_lazy_relationships/core/lazy_relationship_method.rb
@@ -39,15 +39,7 @@ module AmsLazyRelationships::Core
       @lazy_relationships[name] = lrm
 
       define_method :"lazy_#{name}" do
-        # We need to evaluate the promise right before serializer tries
-        # to touch it. Otherwise the various side effects can happen:
-        # 1. AMS will attempt to serialize nil values with a specific V1 serializer
-        # 2. `lazy_association ? 'exists' : 'missing'` expression will always
-        #     equal to 'exists'
-        # 3. `lazy_association&.id` expression can raise NullPointer exception
-        #
-        # Calling `__sync` will evaluate the promise.
-        self.class.send(:load_lazy_relationship, lrm, object).__sync
+        self.class.send(:load_lazy_relationship, name, object)
       end
     end
 

--- a/spec/core_spec.rb
+++ b/spec/core_spec.rb
@@ -105,16 +105,16 @@ RSpec.describe AmsLazyRelationships::Core do
     end
 
     let(:included_level1_ids) do
-      json[:included].map { |i| i[:id].to_i }
+      json[:included].map { |i| i[:id] }
     end
     let(:relationship_level2_ids) do
       json[:included].map do |i|
-        i.dig(:relationships, :level2, :data, :id).try(:to_i)
+        i.dig(:relationships, :level2, :data, :id)
       end
     end
     let(:relationship_level1_ids) do
       json.dig(:data, :relationships, :level1, :data).map do |i|
-        i[:id].to_i
+        i[:id]
       end
     end
 
@@ -211,7 +211,7 @@ RSpec.describe AmsLazyRelationships::Core do
 
   describe "json" do
     let(:included_level1_ids) do
-      json.dig(:user, :level1).map { |i| i[:id].to_i }
+      json.dig(:user, :level1).map { |i| i[:id] }
     end
 
     context "0 level nesting requested" do
@@ -318,7 +318,7 @@ RSpec.describe AmsLazyRelationships::Core do
     end
 
     it "provides a convenience method for lazy relationships" do
-      ids = json.dig(:user, :level1).map { |x| x[:id].to_i }
+      ids = json.dig(:user, :level1).map { |x| x[:id] }
       expect(ids).to match_array(level1_records.map(&:id))
     end
   end
@@ -353,7 +353,7 @@ RSpec.describe AmsLazyRelationships::Core do
     end
 
     it "provides a convenience method for lazy relationships" do
-      id = json.dig(:comment, :level1, :id).to_i
+      id = json.dig(:comment, :level1, :id)
       expect(id).to eq(comment.user_id)
     end
 
@@ -412,7 +412,7 @@ RSpec.describe AmsLazyRelationships::Core do
     end
 
     it "provides a convenience method for lazy relationships" do
-      id = json.dig(:comment, :level1, :id).to_i
+      id = json.dig(:comment, :level1, :id)
       expect(id).to eq(comment.user_id)
     end
 
@@ -465,7 +465,7 @@ RSpec.describe AmsLazyRelationships::Core do
       end
 
       it "yields serializer object and lets to use 'object' method" do
-        id = json.dig(:comment, :level1, :id).to_i
+        id = json.dig(:comment, :level1, :id)
         expect(id).to eq(comment.user_id)
         serialized_name = json.dig(:comment, :level1, :name)
         expect(serialized_name).to eq("x")
@@ -572,10 +572,6 @@ RSpec.describe AmsLazyRelationships::Core do
       Level0Serializer9
     end
 
-    let(:included_level1_ids) do
-      json.dig(:user, :level1).map { |i| i[:id].to_i }
-    end
-
     let(:includes) { ["level1.level2"] }
 
     it "copies relationships to inherited serializer" do
@@ -621,7 +617,7 @@ RSpec.describe AmsLazyRelationships::Core do
     end
   end
 
-  context "straightforward serializers lookup" do
+  describe "straightforward serializers lookup" do
     let(:level0_serializer_class) do
       module Serializer10
         class UserSerializer < BaseTestSerializer
@@ -647,7 +643,7 @@ RSpec.describe AmsLazyRelationships::Core do
     include_examples "lazy loader for nested serializer"
   end
 
-  context "customized serializers lookup" do
+  describe "customized serializers lookup" do
     next unless AMS_VERSION >= Gem::Version.new("0.10.3")
 
     let(:level0_serializer_class) do

--- a/spec/support/with_ar_models.rb
+++ b/spec/support/with_ar_models.rb
@@ -1,44 +1,51 @@
 module WithArModels
   def with_ar_models
     with_model :User do
-      table do |t|
+      table(id: :uuid) do |t|
         t.string :name
         t.timestamps
       end
 
       model do
+        before_create { self.id = SecureRandom.uuid }
         has_many :comments
         has_many :blog_posts
       end
     end
 
     with_model :Category do
-      table do |t|
+      table(id: :uuid) do |t|
         t.timestamps null: false
       end
 
       model do
+        before_create { self.id = SecureRandom.uuid }
         has_many :category_followers
       end
     end
 
     with_model :CategoryFollower do
-      table do |t|
-        t.integer :category_id
+      table(id: :uuid) do |t|
+        t.string :category_id
 
-        t.timestamps null: false
-      end
-    end
-
-    with_model :BlogPost do
-      table do |t|
-        t.string :title
-        t.belongs_to :user
-        t.integer :category_id
         t.timestamps null: false
       end
 
       model do
+        before_create { self.id = SecureRandom.uuid }
+      end
+    end
+
+    with_model :BlogPost do
+      table(id: :uuid) do |t|
+        t.string :title
+        t.string :user_id
+        t.string :category_id
+        t.timestamps null: false
+      end
+
+      model do
+        before_create { self.id = SecureRandom.uuid }
         belongs_to :user
         belongs_to :category
         has_many :comments
@@ -49,14 +56,15 @@ module WithArModels
     end
 
     with_model :Comment do
-      table do |t|
+      table(id: :uuid) do |t|
         t.string :body
-        t.belongs_to :blog_post
-        t.belongs_to :user
+        t.string :blog_post_id
+        t.string :user_id
         t.timestamps
       end
 
       model do
+        before_create { self.id = SecureRandom.uuid }
         belongs_to :user
         belongs_to :blog_post
         belongs_to :blog_post_with_options,


### PR DESCRIPTION
It introduces `lazy_dig` serializer instance method, in order to dig through nested associations keeping laziness and N+1-free evaluation.

```
class AuthorSerializer < BaseSerializer
  lazy_relationship :address
end

class BlogPostSerializer < BaseSerializer
  lazy_relationship :author

  attribute :author_address do
    lazy_dig(:author, :address)&.full_address
  end
end
```

Also we turn all primary keys into UUIDs within a test suite, that is much stronger. Indeed, with auto-increment keys when we assert the things like

```ruby
  expect(json).to eq(blog_posts.map(&:id))
```

it's possible to face with false-positive result when not `BlogPosts` but, say, `Comments` was JSONed, just because

```
blog_posts = 3.times.map { BlogPost.create! }
comments = 3.times.map { Comment.create! }

blog_posts.map(&:id) == comments.map(&:id)
# => true, both of them equal to `[1,2,3]`
```