### PR TITLE
Skip redundant queries when include_data is disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ class UserSerializer < BaseSerializer
   # The previous one is a shorthand for the following lines:
   lazy_relationship :blog_posts, loader: AmsLazyRelationships::Loaders::Association.new("User", :blog_posts)
   has_many :blog_posts, serializer: BlogPostSerializer do |serializer|
+    # non-proc custom finder will work as well, but it can produce redundant sql
+    # queries, please see [Example 2: Modifying the relationship before rendering](#example-2-modifying-the-relationship-before-rendering)
     -> { serializer.lazy_blog_posts }
   end
    
@@ -124,8 +126,17 @@ class BlogPostSerializer < BaseSerializer
 end
 ```
 
-Keep attention that custom finder should be returned in a form of lambda,
-in order to avoid redundant SQL queries when `include_data` AMS setting appears to be `false`:
+Despite the fact that non-block custom finder such as
+
+```ruby
+class BlogPostSerializer < BaseSerializer
+  lazy_has_many :comments do |serializer|
+    serializer.lazy_comments.map(&:decorate)
+   end
+end
+```
+
+will work still, it's better to implement it in a form of lambda, in order to avoid redundant SQL queries when `include_data` AMS setting appears to be `false`:
 
 ```ruby
 class BlogPostSerializer < BaseSerializer
@@ -136,8 +147,7 @@ class BlogPostSerializer < BaseSerializer
 end
 ```
 
-Feel free to skip custom lazy finder for association if your goal is just to
-define `include_data` setting nor some links/metas:
+Feel free to skip custom lazy finder for association if your goal is just to define `include_data` setting and/or to specify some links and metas:
 
 ```ruby
 class BlogPostSerializer < BaseSerializer

--- a/lib/ams_lazy_relationships.rb
+++ b/lib/ams_lazy_relationships.rb
@@ -4,6 +4,7 @@ require "batch-loader"
 require "active_model_serializers"
 
 require "ams_lazy_relationships/version"
+require "ams_lazy_relationships/extensions"
 require "ams_lazy_relationships/loaders"
 require "ams_lazy_relationships/core"
 

--- a/lib/ams_lazy_relationships/extensions.rb
+++ b/lib/ams_lazy_relationships/extensions.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require "ams_lazy_relationships/extensions/reflection"
+
+module AmsLazyRelationships
+  module Extensions
+  end
+end

--- a/lib/ams_lazy_relationships/extensions/reflection.rb
+++ b/lib/ams_lazy_relationships/extensions/reflection.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+# There is a general problem inside AMS related to custom association finder
+# combined with `include_data` setting:
+#
+#   class BlogPost3Serializer < BaseTestSerializer
+#     belongs_to :category do
+#       include_data :if_sideloaded
+#       object.categories.last
+#     end
+#   end
+#
+# The problem is that `belongs_to` block will be fully evaluated each time for
+# each object, and only after that AMS is able to take into account
+# `include_data` mode -
+# https://github.com/rails-api/active_model_serializers/blob/v0.10.10/lib/active_model/serializer/reflection.rb#L162-L163
+#
+#   def value(serializer, include_slice)
+#     # ...
+#     block_value = instance_exec(serializer, &block) if block
+#     return unless include_data?(include_slice)
+#     # ...
+#   end
+#
+# That causing redundant (and so huge potentially!) SQL queries and AR objects
+# allocation when `include_data` appears to be `false` but `belongs_to` block
+# defines instant (not a kind of AR::Relation) custom association finder.
+#
+# Described problem is a very specific use case for pure AMS applications.
+# The bad news is that `ams_lazy_relationships` is always utilize the
+# association block -
+# https://github.com/Bajena/ams_lazy_relationships/blob/v0.2.0/lib/ams_lazy_relationships/core/relationship_wrapper_methods.rb#L32-L36
+#
+# def define_lazy_association(type, name, options, block)
+#   #...
+#   block ||= lambda do |serializer|
+#     serializer.public_send("lazy_#{name}")
+#   end
+#
+#   public_send(type, name.to_sym, real_relationship_options, &block)
+#   #...
+# end
+#
+# This way we break `include_data` optimizations for the host application.
+#
+# In order to overcome that we are forced to monkey-patch
+# `AmsLazyRelationships::Extensions::Reflection#value` method and make it to be
+# ready for Proc returned by association block. This way we will use a kind of
+#
+#   block ||= lambda do |serializer|
+#     -> { serializer.public_send("lazy_#{name}") }
+#   end
+#
+# as association block, then AMS will evaluate it, get the value of `include_data`
+# setting, make a decision do we need to continue with that association, if so -
+# will finally evaluate the proc with lazy relationship inside it.
+
+module AmsLazyRelationships
+  module Extensions
+    module Reflection
+      def value(*)
+        case (block_value = super)
+        when Proc, Method then block_value.call
+        else block_value
+        end
+      end
+    end
+  end
+end
+
+::ActiveModel::Serializer::Reflection.prepend AmsLazyRelationships::Extensions::Reflection

--- a/lib/ams_lazy_relationships/extensions/reflection.rb
+++ b/lib/ams_lazy_relationships/extensions/reflection.rb
@@ -27,7 +27,7 @@
 # defines instant (not a kind of AR::Relation) custom association finder.
 #
 # Described problem is a very specific use case for pure AMS applications.
-# The bad news is that `ams_lazy_relationships` is always utilize the
+# The bad news is that `ams_lazy_relationships` always utilizes the
 # association block -
 # https://github.com/Bajena/ams_lazy_relationships/blob/v0.2.0/lib/ams_lazy_relationships/core/relationship_wrapper_methods.rb#L32-L36
 #

--- a/lib/ams_lazy_relationships/extensions/reflection.rb
+++ b/lib/ams_lazy_relationships/extensions/reflection.rb
@@ -3,7 +3,7 @@
 # There is a general problem inside AMS related to custom association finder
 # combined with `include_data` setting:
 #
-#   class BlogPost3Serializer < BaseTestSerializer
+#   class BlogPostSerializer < BaseSerializer
 #     belongs_to :category do
 #       include_data :if_sideloaded
 #       object.categories.last

--- a/spec/core_spec.rb
+++ b/spec/core_spec.rb
@@ -866,4 +866,102 @@ RSpec.describe AmsLazyRelationships::Core do
       end
     end
   end
+
+  describe 'include_data AMS setting' do
+    next unless AMS_VERSION >= Gem::Version.new("0.10.3")
+
+    shared_examples 'lazy loader when include_data option is set' do
+      let(:adapter_class) { json_api_adapter_class }
+      let(:includes) { ['blog_posts'] }
+      let(:category_data) { json.dig(:included, 0, :relationships, :category, :data) }
+
+      it 'does not fire unnecessary SQL query' do
+        expect { json }
+          .to make_database_queries(count: 1, matching: 'blog_posts')
+          .and make_database_queries(count: 0, matching: 'categories')
+
+        expect(category_data).to be_nil
+      end
+
+      context 'when sideloaded' do
+        let(:includes) { ['blog_posts.category'] }
+
+        it 'fires single SQL query' do
+          expect { json }
+            .to make_database_queries(count: 1, matching: 'blog_posts')
+            .and make_database_queries(count: 1, matching: 'categories')
+
+          expect(category_data).to be_present
+        end
+      end
+    end
+
+    context 'include_data disabled globally' do
+      let(:level0_serializer_class) do
+        module Serializer14
+          class BlogPost1Serializer < BaseTestSerializer
+            lazy_belongs_to :category
+          end
+
+          class User1Serializer < BaseTestSerializer
+            lazy_has_many :blog_posts, serializer: BlogPost1Serializer
+          end
+        end
+
+        Serializer14::User1Serializer
+      end
+
+      around do |example|
+        backup = ActiveModel::Serializer.config.include_data_default
+        ActiveModel::Serializer.config.include_data_default = :if_sideloaded
+
+        example.run
+
+        ActiveModel::Serializer.config.include_data_default = backup
+      end
+
+      include_examples 'lazy loader when include_data option is set'
+    end
+
+    context 'include_data disabled locally with custom finder' do
+      let(:level0_serializer_class) do
+        module Serializer14
+          class BlogPost2Serializer < BaseTestSerializer
+            lazy_belongs_to :category do |serializer|
+              include_data :if_sideloaded
+              -> { serializer.lazy_category }
+            end
+          end
+
+          class User2Serializer < BaseTestSerializer
+            lazy_has_many :blog_posts, serializer: BlogPost2Serializer
+          end
+        end
+
+        Serializer14::User2Serializer
+      end
+
+      include_examples 'lazy loader when include_data option is set'
+    end
+
+    context 'include_data disabled locally without custom finder' do
+      let(:level0_serializer_class) do
+        module Serializer14
+          class BlogPost3Serializer < BaseTestSerializer
+            lazy_belongs_to :category do
+              include_data :if_sideloaded
+            end
+          end
+
+          class User3Serializer < BaseTestSerializer
+            lazy_has_many :blog_posts, serializer: BlogPost3Serializer
+          end
+        end
+
+        Serializer14::User3Serializer
+      end
+
+      include_examples 'lazy loader when include_data option is set'
+    end
+  end
 end


### PR DESCRIPTION
There is a general problem inside AMS related to custom association finder combined with `include_data` setting:

```ruby
  class BlogPost3Serializer < BaseTestSerializer
    belongs_to :category do
      include_data :if_sideloaded
      object.categories.last
    end
  end
```

The problem is that `belongs_to` block [will be fully evaluated](https://github.com/rails-api/active_model_serializers/blob/v0.10.10/lib/active_model/serializer/reflection.rb#L162-L163) each time for each object, and only after that AMS is able to take into account `include_data` mode -

```ruby
  def value(serializer, include_slice)
    # ...
    block_value = instance_exec(serializer, &block) if block
    return unless include_data?(include_slice)
    # ...
  end
```

That causing redundant (and so huge potentially!) SQL queries and AR objects allocation when `include_data` appears to be `false` but `belongs_to` block defines instant (not a kind of AR::Relation) custom association finder.

Described problem is a very specific use case for pure AMS applications. The bad news is that `ams_lazy_relationships` is [always utilize](https://github.com/Bajena/ams_lazy_relationships/blob/v0.2.0/lib/ams_lazy_relationships/core/relationship_wrapper_methods.rb#L32-L36) the association block -

```ruby
def define_lazy_association(type, name, options, block)
  #...
  block ||= lambda do |serializer|
    serializer.public_send("lazy_#{name}")
  end

  public_send(type, name.to_sym, real_relationship_options, &block)
  #...
end
```

This way we break `include_data` optimizations for the host application.

In order to overcome that we are forced to monkey-patch `AmsLazyRelationships::Extensions::Reflection#value` method and make it to be ready for Proc returned by association block. This way we will use a kind of

```ruby
  block ||= lambda do |serializer|
    -> { serializer.public_send("lazy_#{name}") }
  end
```

as association block, then AMS will evaluate it, get the value of `include_data`
setting, make a decision do we need to continue with that association, if so -
will finally evaluate the proc with lazy relationship inside it.

In additional, now we allow skipping the custom lazy finder when our goal is just to define `include_data` setting nor some links/metas:

```ruby
  lazy_has_many :comments do
    include_data :if_sideloaded
    link :self, 'a link'
    meta name: 'Dan Brown'
   end
```