### PR TITLE
Skip active_support as redundant dependency

### DIFF
--- a/lib/ams_lazy_relationships.rb
+++ b/lib/ams_lazy_relationships.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 require "batch-loader"
-
-# That is a missing dependency of AMS v0.10.0.rc4 in fact (
-require "active_support/core_ext/string/inflections"
 require "active_model_serializers"
 
 require "ams_lazy_relationships/version"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,9 @@ SimpleCov.start do
 end
 
 require "bundler/setup"
+
+# That is a missing dependency of AMS v0.10.0.rc4 in fact (
+require "active_support/core_ext/string/inflections"
 require "ams_lazy_relationships"
 
 require "undercover"


### PR DESCRIPTION
Move `active_support` dependency to `spec_helper` since it is needed for AMS v0.10.0.rc4 only