### PR TITLE
Fix association duplicates after accepts_nested_attributes_for assignation

### DIFF
--- a/spec/core_spec.rb
+++ b/spec/core_spec.rb
@@ -129,6 +129,15 @@ RSpec.describe AmsLazyRelationships::Core do
       it "renders correct results" do
         expect(relationship_level1_ids).to match_array(level1_records.map(&:id))
       end
+
+      context "association populated by accepts_nested_attributes_for" do
+        let(:user) { User.create!(blog_posts_attributes: [{title: 'Foo'}]) }
+        let(:level1_records) { [] }
+
+        it "avoids the duplication of associated records" do
+          expect(relationship_level1_ids.size).to eq(1)
+        end
+      end
     end
 
     context "1 level nesting requested" do

--- a/spec/loaders/association_spec.rb
+++ b/spec/loaders/association_spec.rb
@@ -256,6 +256,15 @@ RSpec.describe AmsLazyRelationships::Loaders::Association do
         expect(t2).to eq([comment2])
       end
     end
+
+    context "association populated by accepts_nested_attributes_for" do
+      let(:record) { User.create!(blog_posts_attributes: [{title: 'Foo'}]) }
+      let(:loader) { described_class.new("User", :blog_posts) }
+
+      it "avoids the duplication of associated records" do
+        expect(loader.load(record).size).to eq(1)
+      end
+    end
   end
 
   context "when loading multiple lazy associations" do

--- a/spec/support/with_ar_models.rb
+++ b/spec/support/with_ar_models.rb
@@ -10,6 +10,7 @@ module WithArModels
         before_create { self.id = SecureRandom.uuid }
         has_many :comments
         has_many :blog_posts
+        accepts_nested_attributes_for :blog_posts
       end
     end
 


### PR DESCRIPTION
One more case when duplicated records appear in has_many relationships is the recent assignation to `accept_nested_attributes_for` setter.

ActiveRecord will not mark the association as `loaded` but in same time will keep internal representation of the nested records created by `accept_nested_attributes_for`. Then Associations::Preloader is going to merge internal state of associated records with the same records recently stored in DB. `r.association(association_name).reset` effectively fixes that.