### PR TITLE
Undercover GitHub App workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: Rails Unit Tests
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Ruby 3.1.2
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.1.2
+      - name: Build and test with Rake
+        env:
+          RAILS_ENV: test
+        run: |
+          gem install bundler
+          bundle install --jobs 4 --retry 3
+          bundle exec rspec
+          ruby -e "$(curl -s https://undercover-ci.com/uploader.rb)" -- \
+          --repo ${{ github.repository }} \
+          --commit ${{ github.workflow_sha }} \
+          --lcov coverage/lcov/ams_lazy_relationships.lcov

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -244,7 +244,7 @@ DEPENDENCIES
   simplecov-lcov
   sqlite3
   thread_safe
-  undercover
+  undercover (~> 0.4)
   with_model
 
 BUNDLED WITH

--- a/ams_lazy_relationships.gemspec
+++ b/ams_lazy_relationships.gemspec
@@ -53,7 +53,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "simplecov-lcov"
   spec.add_development_dependency "sqlite3"
   # Detect untested code blocks in recent changes
-  spec.add_development_dependency "undercover"
+  spec.add_development_dependency "undercover", "~> 0.4"
   # Dynamically build an Active Record model (with table) within a test context
   spec.add_development_dependency "with_model"
 


### PR DESCRIPTION
Initial setup for test coverage using hosted Undercover 🔍 

You'll need to install Undercover GitHub App on `Bajena/ams_lazy_relationships` [here](https://undercover-ci.com) (free) and the GitHub Action should work exactly like in this [demo PR on my fork](https://github.com/grodowski/ams_lazy_relationships/pull/1/files).